### PR TITLE
Remove DokkaTask cache exclusion

### DIFF
--- a/.github/workflows/run-experiments-apollo.yml
+++ b/.github/workflows/run-experiments-apollo.yml
@@ -33,7 +33,6 @@ jobs:
         run: |
           mkdir ~/git-hooks
           echo -e 'echo "\ntasks.withType<org.jetbrains.intellij.tasks.BuildPluginTask>().configureEach { outputs.doNotCacheIf(\"buildPlugin should not be cacheable as it is a Zip task\") { true } }" >> intellij-plugin/build.gradle.kts\n' >> ~/git-hooks/post-checkout
-          echo -e 'echo "\nsubprojects { tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach { outputs.doNotCacheIf(\"https://github.com/Kotlin/dokka/issues/2978\") { true } } }" >> build.gradle.kts\n' >> ~/git-hooks/post-checkout
           chmod +x ~/git-hooks/post-checkout
           git config --global core.hooksPath ~/git-hooks
       - name: Download latest version of the validation scripts


### PR DESCRIPTION
In draft: verifying build succeeds

Dokka is no longer used by apollo-kotlin, they have moved to dokkatoo