### PR TITLE
Use `ubuntu-latest` runners for Apache Beam and Spring Boot experiments

### DIFF
--- a/.github/workflows/run-experiments-apache-beam.yml
+++ b/.github/workflows/run-experiments-apache-beam.yml
@@ -22,12 +22,7 @@ jobs:
           - experimentId: 2
           - experimentId: 3
 
-    runs-on:
-      # This `runs-on` configuration utilize larger GitHub Actions hosted runners. This build does not successfully
-      # complete on the default runners.
-      # Using this label incurs extra costs, so please do not copy/paste this configuration.
-      labels: ubuntu-latest-4core
-      group: gradle-enterprise-oss-projects
+    runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 8
         uses: actions/setup-java@v4

--- a/.github/workflows/run-experiments-apache-beam.yml
+++ b/.github/workflows/run-experiments-apache-beam.yml
@@ -24,6 +24,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          docker-images: false
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/run-experiments-spring-boot.yml
+++ b/.github/workflows/run-experiments-spring-boot.yml
@@ -22,12 +22,7 @@ jobs:
           - experimentId: 2
           - experimentId: 3
 
-    runs-on:
-      # This `runs-on` configuration utilize larger GitHub Actions hosted runners. This build does not successfully
-      # complete on the default runners.
-      # Using this label incurs extra costs, so please do not copy/paste this configuration.
-      labels: ubuntu-latest-4core
-      group: gradle-enterprise-oss-projects
+    runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/run-experiments-spring-boot.yml
+++ b/.github/workflows/run-experiments-spring-boot.yml
@@ -24,6 +24,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          docker-images: false
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
In January, [GitHub bumped the specs of the default runners](https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/):

> We are pleased to announce that we completed that upgrade today, and we now provide machines that are double their previous specification, with 4-vCPUs, 16 GiB of memory.

Both Apache Beam and Spring Boot are using paid-for runners with the exact specifications as the standard runners. However, the standard runners quickly run out of disk space. Both builds were failing due to insufficient disk space in my initial testing.

I did some digging and discovered the Spring Boot project [recently switched](https://github.com/spring-projects/spring-boot/commit/90aae5a0b74164cfff300052407617238c758fe7) to using `ubuntu-latest`. I noticed they introduced [this jlumbroso/free-disk-space action](https://github.com/spring-projects/spring-boot/blob/ea544822f6150fdb332b2f1ebaf1176e41db82ed/.github/actions/prepare-gradle-build/action.yml#L18-L22) as part of those changes.

I tried using this same action and both the [Beam](https://github.com/gradle/develocity-oss-projects/actions/runs/9896447420/job/27338684246#step:8:16103) and [Boot](https://github.com/gradle/develocity-oss-projects/actions/runs/9896184589/job/27337793880#step:7:1615) experiments finished successfully.

This PR reverts both Apache Beam and Spring Boot to using the standard runners