### PR TITLE
Disable fail fast in all experiment workflows

### DIFF
--- a/.github/workflows/run-experiments-androidx.yml
+++ b/.github/workflows/run-experiments-androidx.yml
@@ -18,6 +18,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-apache-beam.yml
+++ b/.github/workflows/run-experiments-apache-beam.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-apache-calcite.yml
+++ b/.github/workflows/run-experiments-apache-calcite.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-apache-geode.yml
+++ b/.github/workflows/run-experiments-apache-geode.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-apache-groovy.yml
+++ b/.github/workflows/run-experiments-apache-groovy.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-apache-james.yml
+++ b/.github/workflows/run-experiments-apache-james.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-apache-jmeter.yml
+++ b/.github/workflows/run-experiments-apache-jmeter.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-apache-kafka.yml
+++ b/.github/workflows/run-experiments-apache-kafka.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-apache-lucene.yml
+++ b/.github/workflows/run-experiments-apache-lucene.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-apache-ofbiz.yml
+++ b/.github/workflows/run-experiments-apache-ofbiz.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-apache-openwhisk.yml
+++ b/.github/workflows/run-experiments-apache-openwhisk.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-apache-samza.yml
+++ b/.github/workflows/run-experiments-apache-samza.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-apache-solr.yml
+++ b/.github/workflows/run-experiments-apache-solr.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-apereo-cas.yml
+++ b/.github/workflows/run-experiments-apereo-cas.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-apollo.yml
+++ b/.github/workflows/run-experiments-apollo.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-armeria.yml
+++ b/.github/workflows/run-experiments-armeria.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-caffeine.yml
+++ b/.github/workflows/run-experiments-caffeine.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-detekt.yml
+++ b/.github/workflows/run-experiments-detekt.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-gradle.yml
+++ b/.github/workflows/run-experiments-gradle.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-grails-core.yml
+++ b/.github/workflows/run-experiments-grails-core.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-hibernate-orm.yml
+++ b/.github/workflows/run-experiments-hibernate-orm.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-hibernate-search.yml
+++ b/.github/workflows/run-experiments-hibernate-search.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-jhipster.yml
+++ b/.github/workflows/run-experiments-jhipster.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-junit5.yml
+++ b/.github/workflows/run-experiments-junit5.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-kotlin.yml
+++ b/.github/workflows/run-experiments-kotlin.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-micrometer.yml
+++ b/.github/workflows/run-experiments-micrometer.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-micronaut-aws.yml
+++ b/.github/workflows/run-experiments-micronaut-aws.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-micronaut-core.yml
+++ b/.github/workflows/run-experiments-micronaut-core.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-micronaut-data.yml
+++ b/.github/workflows/run-experiments-micronaut-data.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-micronaut-kafka.yml
+++ b/.github/workflows/run-experiments-micronaut-kafka.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-micronaut-kotlin.yml
+++ b/.github/workflows/run-experiments-micronaut-kotlin.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-micronaut-security.yml
+++ b/.github/workflows/run-experiments-micronaut-security.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-micronaut-spring.yml
+++ b/.github/workflows/run-experiments-micronaut-spring.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-micronaut-starter.yml
+++ b/.github/workflows/run-experiments-micronaut-starter.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-microstream.yml
+++ b/.github/workflows/run-experiments-microstream.yml
@@ -17,6 +17,7 @@ jobs:
     Experiment:
 
         strategy:
+            fail-fast: false
             matrix:
                 include:
                     - experimentId: 1

--- a/.github/workflows/run-experiments-misc-java-ordered-properties.yml
+++ b/.github/workflows/run-experiments-misc-java-ordered-properties.yml
@@ -16,6 +16,7 @@ jobs:
   build_cache:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-misc-wrapper-upgrade-gradle-plugin.yml
+++ b/.github/workflows/run-experiments-misc-wrapper-upgrade-gradle-plugin.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-nokee.yml
+++ b/.github/workflows/run-experiments-nokee.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-openapi.yml
+++ b/.github/workflows/run-experiments-openapi.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-openrewrite.yml
+++ b/.github/workflows/run-experiments-openrewrite.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-quarkus.yml
+++ b/.github/workflows/run-experiments-quarkus.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-ratpack.yml
+++ b/.github/workflows/run-experiments-ratpack.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-spock.yml
+++ b/.github/workflows/run-experiments-spock.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-spring-amqp.yml
+++ b/.github/workflows/run-experiments-spring-amqp.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-spring-authorization-server.yml
+++ b/.github/workflows/run-experiments-spring-authorization-server.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-spring-boot.yml
+++ b/.github/workflows/run-experiments-spring-boot.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-spring-framework.yml
+++ b/.github/workflows/run-experiments-spring-framework.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-spring-kafka.yml
+++ b/.github/workflows/run-experiments-spring-kafka.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-spring-security.yml
+++ b/.github/workflows/run-experiments-spring-security.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-testcontainers.yml
+++ b/.github/workflows/run-experiments-testcontainers.yml
@@ -16,6 +16,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1

--- a/.github/workflows/run-experiments-xwiki.yml
+++ b/.github/workflows/run-experiments-xwiki.yml
@@ -17,6 +17,7 @@ jobs:
   Experiment:
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - experimentId: 1


### PR DESCRIPTION
This PR disables fail fast in all workflows.

https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures

This option cancels other jobs in the same matrix when one of them fails. See [this example](https://github.com/gradle/develocity-oss-projects/actions/runs/9896184589), where there were executed cacheable tasks in experiment 2 and experiments 1 & 3 were cancelled. The other jobs should have finished soon after.