### PR TITLE
Filter out flaky test classes from Apache Samza experiment execution

### DIFF
--- a/.github/workflows/run-experiments-apache-samza.yml
+++ b/.github/workflows/run-experiments-apache-samza.yml
@@ -27,12 +27,10 @@ jobs:
         with:
           java-version: 8
           distribution: "temurin"
-      - name: Add git hook to exclude flaky test classes
+      - name: Add git hook to enable test retry
         run: |
           mkdir ~/git-hooks
-          echo -e 'echo "\nproject(\":samza-core_\$scalaSuffix\") { test { filter { excludeTestsMatching \"org.apache.samza.container.TestRunLoop\"} } }" >> build.gradle\n' >> ~/git-hooks/post-checkout
-          echo -e 'echo "\nproject(\":samza-kafka_\$scalaSuffix\") { test { filter { excludeTestsMatching \"org.apache.samza.system.kafka.TestKafkaSystemAdminJava\" excludeTestsMatching \"org.apache.samza.system.kafka.TestKafkaSystemFactoryJava\" } } }" >> build.gradle\n' >> ~/git-hooks/post-checkout
-          echo -e 'echo "\nproject(\":samza-test_\$scalaSuffix\") { test { filter { excludeTestsMatching \"org.apache.samza.storage.kv.BlobStoreStateBackendIntegrationTest\" } } }" >> build.gradle\n' >> ~/git-hooks/post-checkout
+          echo -e 'echo "\nallprojects { tasks.withType(Test).configureEach { retry { maxRetries = 3 } } }" >> build.gradle\n' >> ~/git-hooks/post-checkout
           chmod +x ~/git-hooks/post-checkout
           git config --global core.hooksPath ~/git-hooks
       - name: Download latest version of the validation scripts

--- a/.github/workflows/run-experiments-apache-samza.yml
+++ b/.github/workflows/run-experiments-apache-samza.yml
@@ -27,6 +27,14 @@ jobs:
         with:
           java-version: 8
           distribution: "temurin"
+      - name: Add git hook to exclude flaky test classes
+        run: |
+          mkdir ~/git-hooks
+          echo -e 'echo "\nproject(\":samza-core_\$scalaSuffix\") { test { filter { excludeTestsMatching \"org.apache.samza.container.TestRunLoop\"} } }" >> build.gradle\n' >> ~/git-hooks/post-checkout
+          echo -e 'echo "\nproject(\":samza-kafka_\$scalaSuffix\") { test { filter { excludeTestsMatching \"org.apache.samza.system.kafka.TestKafkaSystemAdminJava\" excludeTestsMatching \"org.apache.samza.system.kafka.TestKafkaSystemFactoryJava\" } } }" >> build.gradle\n' >> ~/git-hooks/post-checkout
+          echo -e 'echo "\nproject(\":samza-test_\$scalaSuffix\") { test { filter { excludeTestsMatching \"org.apache.samza.storage.kv.BlobStoreStateBackendIntegrationTest\" } } }" >> build.gradle\n' >> ~/git-hooks/post-checkout
+          chmod +x ~/git-hooks/post-checkout
+          git config --global core.hooksPath ~/git-hooks
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:


### PR DESCRIPTION
Add a git hook that adds test exclusion filters to prevent [the test classes that are currently showing as flaky in Develocity](https://ge.solutions-team.gradle.com/scans/tests?search.relativeStartTime=P90D&search.rootProjectNames=*samza*&search.timeZoneId=America%2FChicago) from executing.

Experiment [workflow](https://github.com/gradle/develocity-oss-projects/actions/runs/10388383528) passes with these changes.

(They configure all their projects using the `project("projectName") { }` syntax from the root `build.gradle` - that's why I did the same in these changes)