### PR TITLE
Fix armeria OSS experiments

### DIFF
--- a/.github/workflows/run-experiments-armeria.yml
+++ b/.github/workflows/run-experiments-armeria.yml
@@ -9,7 +9,7 @@ on:
 env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/line/armeria"
-  TASKS: "build -Pretry=true -PfailOnPassedAfterRetry=false -PnoLint -PflakyTests=false -PbuildJdkVersion=21 -PtestJavaVersion=21 -PpreferShadedTests=false"
+  TASKS: "build --no-daemon --max-workers=2 --parallel -PbuildJdkVersion=21 -Pretry=true -PfailOnPassedAfterRetry=false -PnoLint -PflakyTests=false"
 
 jobs:
   Experiment:
@@ -18,8 +18,8 @@ jobs:
       matrix:
         include:
           - experimentId: 1
-#          - experimentId: 2
-#          - experimentId: 3
+          - experimentId: 2
+          - experimentId: 3
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 21

--- a/.github/workflows/run-experiments-armeria.yml
+++ b/.github/workflows/run-experiments-armeria.yml
@@ -9,7 +9,7 @@ on:
 env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/line/armeria"
-  TASKS: "build -Pretry=true -PfailOnPassedAfterRetry=false -PnoLint -PflakyTests=false -PbuildJdkVersion=19 -PtestJavaVersion=19"
+  TASKS: "build -Pretry=true -PfailOnPassedAfterRetry=false -PnoLint -PflakyTests=false -PbuildJdkVersion=21 -PtestJavaVersion=21 -PpreferShadedTests=false"
 
 jobs:
   Experiment:
@@ -18,14 +18,15 @@ jobs:
       matrix:
         include:
           - experimentId: 1
-          - experimentId: 2
-          - experimentId: 3
+#          - experimentId: 2
+#          - experimentId: 3
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 19
+      - name: Set up JDK 21
+        id: setup-jdk
         uses: actions/setup-java@v4
         with:
-          java-version: 19
+          java-version: 21
           distribution: "temurin"
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
@@ -37,7 +38,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: "${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}"
         with:
           gitRepo: ${{ env.GIT_REPO }}
-          tasks: ${{ env.TASKS }}
+          tasks: ${{ env.TASKS }} "-Porg.gradle.java.installations.paths=${{ steps.setup-jdk.outputs.path }}"
           gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
         if: matrix.experimentId == 1
       - name: Run experiment 2
@@ -46,7 +47,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: "${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}"
         with:
           gitRepo: ${{ env.GIT_REPO }}
-          tasks: ${{ env.TASKS }}
+          tasks: ${{ env.TASKS }} "-Porg.gradle.java.installations.paths=${{ steps.setup-jdk.outputs.path }}"
           gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
           failIfNotFullyCacheable: true
         if: matrix.experimentId == 2
@@ -56,7 +57,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: "${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}"
         with:
           gitRepo: ${{ env.GIT_REPO }}
-          tasks: ${{ env.TASKS }}
+          tasks: ${{ env.TASKS }} "-Porg.gradle.java.installations.paths=${{ steps.setup-jdk.outputs.path }}"
           gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
           failIfNotFullyCacheable: true
         if: matrix.experimentId == 3


### PR DESCRIPTION
Updated armeria workflow to limit max number of workers, same as they do for [cache seed builds](https://github.com/line/armeria/blob/fa5d2a1695e39a5585b45d48a1aedc7d300723e4/.github/workflows/gradle-enterprise-postjob.yml#L136), as well as updated it to use JDK 21, as Armeria does in [their runs](https://github.com/line/armeria/blob/fa5d2a1695e39a5585b45d48a1aedc7d300723e4/.github/workflows/gradle-enterprise-postjob.yml#L32).

You can see the fixed experiment [here](https://github.com/gradle/develocity-oss-projects/actions/runs/10418094643).