### PR TITLE
Fixed the apollo-kotlin experiments

### DIFF
--- a/.github/workflows/run-experiments-apollo-kotlin.yml
+++ b/.github/workflows/run-experiments-apollo-kotlin.yml
@@ -28,12 +28,6 @@ jobs:
         with:
           java-version: 17
           distribution: "temurin"
-      - name: Add git hook to temporarily disable caching for :intellij-plugin:instrumentCode
-        run: |
-          mkdir ~/git-hooks
-          echo -e 'echo "\ntasks.withType<org.jetbrains.intellij.tasks.BuildPluginTask>().configureEach { outputs.doNotCacheIf(\"buildPlugin should not be cacheable as it is a Zip task\") { true } }" >> intellij-plugin/build.gradle.kts\n' >> ~/git-hooks/post-checkout
-          chmod +x ~/git-hooks/post-checkout
-          git config --global core.hooksPath ~/git-hooks
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:


### PR DESCRIPTION
Removed the git hook from apollo-kotlin, as the task in hand has disabled caching from [the source](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/main/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/BuildPluginTask.kt). This was done with their release of 2.0.0, which also moved package coordinates, which caused the configuration to fail, as the task was no longer at the coordinates the hook specified.

You can see the fixed action run [here](https://github.com/gradle/develocity-oss-projects/actions/runs/10452704695).