### PR TITLE
Fix hibernate-orm build by using JDK 17

### DIFF
--- a/.github/workflows/run-experiments-hibernate-orm.yml
+++ b/.github/workflows/run-experiments-hibernate-orm.yml
@@ -22,10 +22,10 @@ jobs:
           - experimentId: 3
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: "temurin"
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable


### PR DESCRIPTION
Build now requires JDK 17, see [failure](https://github.com/gradle/develocity-oss-projects/actions/runs/10439374683/job/28907910301) using JDK 11