### PR TITLE
Fix Apache James Workflow Failures

### DIFF
--- a/.github/workflows/run-experiments-apache-james.yml
+++ b/.github/workflows/run-experiments-apache-james.yml
@@ -10,7 +10,7 @@ env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/apache/james-project"
   GOALS: "verify"
-  ARGS: "-T 1C -B -Dmaven.test.failure.ignore=true"
+  ARGS: "-B -Dmaven.test.failure.ignore=true"
 
 jobs:
   Experiment:

--- a/.github/workflows/run-experiments-apache-james.yml
+++ b/.github/workflows/run-experiments-apache-james.yml
@@ -10,7 +10,7 @@ env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/apache/james-project"
   GOALS: "verify"
-  ARGS: "-Dmaven.test.failure.ignore=true"
+  ARGS: "-T 1C -B -Dmaven.test.failure.ignore=true"
 
 jobs:
   Experiment:

--- a/.github/workflows/run-experiments-apache-james.yml
+++ b/.github/workflows/run-experiments-apache-james.yml
@@ -10,7 +10,7 @@ env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/apache/james-project"
   GOALS: "verify"
-  ARGS: "-Dsurefire.rerunFailingTestsCount=2"
+  ARGS: "-Dmaven.test.failure.ignore=true"
 
 jobs:
   Experiment:

--- a/.github/workflows/run-experiments-apache-james.yml
+++ b/.github/workflows/run-experiments-apache-james.yml
@@ -22,6 +22,8 @@ jobs:
           - experimentId: 2
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/run-experiments-apache-james.yml
+++ b/.github/workflows/run-experiments-apache-james.yml
@@ -10,6 +10,7 @@ env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/apache/james-project"
   GOALS: "verify"
+  ARGS: "-Dsurefire.rerunFailingTestsCount=2"
 
 jobs:
   Experiment:
@@ -37,6 +38,7 @@ jobs:
         with:
           gitRepo: ${{ env.GIT_REPO }}
           goals: ${{ env.GOALS }}
+          args: ${{ env.ARGS }}
           gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
           failIfNotFullyCacheable: true
         if: matrix.experimentId == 1
@@ -47,6 +49,7 @@ jobs:
         with:
           gitRepo: ${{ env.GIT_REPO }}
           goals: ${{ env.GOALS }}
+          args: ${{ env.ARGS }}
           gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
           failIfNotFullyCacheable: true
         if: matrix.experimentId == 2

--- a/.github/workflows/run-experiments-apache-james.yml
+++ b/.github/workflows/run-experiments-apache-james.yml
@@ -21,10 +21,10 @@ jobs:
           - experimentId: 2
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: "temurin"
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/download@actions-stable


### PR DESCRIPTION
* Update from JDK 11 to JDK 21
* Ignore test failures as there are a large number of them without obvious fixes
* Apply the `free-disk-space` action to prevent the runner from running out of space