### PR TITLE
Exclude checkstyleMain task when building hibernate-orm

### DIFF
--- a/.github/workflows/run-experiments-hibernate-orm.yml
+++ b/.github/workflows/run-experiments-hibernate-orm.yml
@@ -9,7 +9,7 @@ on:
 env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/hibernate/hibernate-orm"
-  TASKS: "check"
+  TASKS: "check -x checkstyleMain"
 
 jobs:
   Experiment:


### PR DESCRIPTION
### Issue
`CheckstyleMain` task is [failing](https://ge.solutions-team.gradle.com/s/5vufjofrctm5s/failure#1)

This is however not failing in the repository's CI as the task was recently [excluded from the task graph](https://github.com/hibernate/hibernate-orm/commit/27db2668b455b3aaa6a9de5ba5942c03cfe60643#diff-0f42fd993ce699d1eaf4007157dd696e37a4ad3f424642cf0e504cfba2faa97eL83)

### Fix
Apply the same exclusion in the automated experiments