### PR TITLE
Use latest BVS development release for select workflows

### DIFF
--- a/.github/workflows/run-experiments-apache-beam.yml
+++ b/.github/workflows/run-experiments-apache-beam.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Remove Maven Settings
         # Beam uses the [gradle-maven-settings-plugin](https://github.com/mark-vieira/gradle-maven-settings-plugin/)

--- a/.github/workflows/run-experiments-apache-calcite.yml
+++ b/.github/workflows/run-experiments-apache-calcite.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-apache-geode.yml
+++ b/.github/workflows/run-experiments-apache-geode.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Ignore Test Failures
         run: |

--- a/.github/workflows/run-experiments-apache-groovy.yml
+++ b/.github/workflows/run-experiments-apache-groovy.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-apache-james.yml
+++ b/.github/workflows/run-experiments-apache-james.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-apache-jmeter.yml
+++ b/.github/workflows/run-experiments-apache-jmeter.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Ignore Test Failures
         run: |

--- a/.github/workflows/run-experiments-apache-kafka.yml
+++ b/.github/workflows/run-experiments-apache-kafka.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Ignore Test Failures
         run: |

--- a/.github/workflows/run-experiments-apache-lucene.yml
+++ b/.github/workflows/run-experiments-apache-lucene.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-apache-ofbiz.yml
+++ b/.github/workflows/run-experiments-apache-ofbiz.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-apache-openwhisk.yml
+++ b/.github/workflows/run-experiments-apache-openwhisk.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-apache-samza.yml
+++ b/.github/workflows/run-experiments-apache-samza.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-apache-solr.yml
+++ b/.github/workflows/run-experiments-apache-solr.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-grails-core.yml
+++ b/.github/workflows/run-experiments-grails-core.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-microstream.yml
+++ b/.github/workflows/run-experiments-microstream.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-openapi-generator.yml
+++ b/.github/workflows/run-experiments-openapi-generator.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-quarkus.yml
+++ b/.github/workflows/run-experiments-quarkus.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-spring-amqp.yml
+++ b/.github/workflows/run-experiments-spring-amqp.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-spring-authorization-server.yml
+++ b/.github/workflows/run-experiments-spring-authorization-server.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-spring-boot.yml
+++ b/.github/workflows/run-experiments-spring-boot.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Ignore Test Failures
         run: |

--- a/.github/workflows/run-experiments-spring-framework.yml
+++ b/.github/workflows/run-experiments-spring-framework.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-spring-kafka.yml
+++ b/.github/workflows/run-experiments-spring-kafka.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-spring-security.yml
+++ b/.github/workflows/run-experiments-spring-security.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable


### PR DESCRIPTION
This PR updates all Apache and Spring workflows to use the latest development release of the Develocity Build Validation Scripts. The purpose of this is to regularly verify the development releases against real world projects.

In addition to all Apache and Spring workflows, I have hand selected the following to also use the latest development version:

- Grails Core – because this was the project which surfaced the most recently encountered issue
- The following Maven projects, because otherwise we would have only Apache James
  - Microstream
  - OpenAPI Generator
  - Quarkus
  - XWiki