### PR TITLE
"Misc" is removed from OSS project workflow names

### DIFF
--- a/.github/workflows/run-experiments-java-ordered-properties.yml
+++ b/.github/workflows/run-experiments-java-ordered-properties.yml
@@ -1,4 +1,4 @@
-name: Misc - Java Ordered Properties
+name: Java Ordered Properties
 
 on:
   schedule:

--- a/.github/workflows/run-experiments-wrapper-upgrade-gradle-plugin.yml
+++ b/.github/workflows/run-experiments-wrapper-upgrade-gradle-plugin.yml
@@ -1,4 +1,4 @@
-name: Misc - Wrapper Upgrade Gradle Plugin
+name: Wrapper Upgrade Gradle Plugin
 
 on:
   schedule:


### PR DESCRIPTION
This PR removes the "Misc" distinction for some workflows.