### PR TITLE
Fix JDK version workflow failures

### DIFF
--- a/.github/workflows/run-experiments-apache-lucene.yml
+++ b/.github/workflows/run-experiments-apache-lucene.yml
@@ -22,10 +22,10 @@ jobs:
           - experimentId: 3
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 17
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: "temurin"
       - name: Download latest version of the validation scripts
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable

--- a/.github/workflows/run-experiments-apache-solr.yml
+++ b/.github/workflows/run-experiments-apache-solr.yml
@@ -22,10 +22,10 @@ jobs:
           - experimentId: 3
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 17
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: "temurin"
       - name: Add git hook to temporarily disable caching for SpotlessTaskImpl tasks
         run: |

--- a/.github/workflows/run-experiments-spring-amqp.yml
+++ b/.github/workflows/run-experiments-spring-amqp.yml
@@ -22,10 +22,10 @@ jobs:
           - experimentId: 3
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 17
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 23
           distribution: "temurin"
       - name: Download latest version of the validation scripts
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable


### PR DESCRIPTION
- Solr: Update JDK to 21 (based on [their workflows][1]). [Workflow][2] no longer fails due to JDK (though it fails for cache misses).
- Lucene: Update JDK to 21 (based on [their workflows][3]). [Workflow][6] no longer fails due to JDK version (though it fails for a different reason)
- Spring AMQP: Updated JDK to 23 (based on the [workflow error msg][4]). [Workflow][5] now passes

[1]: https://github.com/apache/solr/blob/main/.github/workflows/gradle-precommit.yml#L26
[2]: https://github.com/gradle/develocity-oss-projects/actions/runs/13461600968
[3]: https://github.com/apache/lucene/blob/main/.github/workflows/run-checks-all.yml#L32
[4]: https://github.com/gradle/develocity-oss-projects/actions/runs/13353503627/job/37293069525#step:6:647
[5]: https://github.com/gradle/develocity-oss-projects/actions/runs/13505119226
[6]: https://github.com/gradle/develocity-oss-projects/actions/runs/13505123645/job/37733557974