### PR TITLE
Fix API timeout workflow failures

### DIFF
--- a/.github/workflows/run-experiments-apache-calcite.yml
+++ b/.github/workflows/run-experiments-apache-calcite.yml
@@ -11,6 +11,7 @@ env:
   GIT_REPO: "https://github.com/apache/calcite"
   TASKS: "build"
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx1024m" -XX:MaxMetaspaceSize="512m" # This was seen in one of their CI jobs
+  READ_TIMEOUT: "PT30S"
 
 jobs:
   Experiment:
@@ -33,6 +34,8 @@ jobs:
         with:
           downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Increase API calls timeout
+        run: echo "read.timeout=$READ_TIMEOUT" | tee -a develocity-gradle-build-validation/network.settings
       - name: Run experiment 1
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
         env:

--- a/.github/workflows/run-experiments-apache-groovy.yml
+++ b/.github/workflows/run-experiments-apache-groovy.yml
@@ -10,6 +10,7 @@ env:
   DEVELOCITY_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/apache/groovy"
   TASKS: "test"
+  READ_TIMEOUT: "PT30S"
 
 jobs:
   Experiment:
@@ -32,6 +33,8 @@ jobs:
         with:
           downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Increase API calls timeout
+        run: echo "read.timeout=$READ_TIMEOUT" | tee -a network.settings
       - name: Run experiment 1
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
         env:

--- a/.github/workflows/run-experiments-apache-groovy.yml
+++ b/.github/workflows/run-experiments-apache-groovy.yml
@@ -34,7 +34,7 @@ jobs:
           downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Increase API calls timeout
-        run: echo "read.timeout=$READ_TIMEOUT" | tee -a network.settings
+        run: echo "read.timeout=$READ_TIMEOUT" | tee -a develocity-gradle-build-validation/network.settings
       - name: Run experiment 1
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
         env:

--- a/.github/workflows/run-experiments-apache-jmeter.yml
+++ b/.github/workflows/run-experiments-apache-jmeter.yml
@@ -10,6 +10,7 @@ env:
   DEVELOCITY_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/apache/jmeter"
   TASKS: "build -x distTar -x distTarSource -x distTarSha512 -x distTarSourceSha512"
+  READ_TIMEOUT: "PT30S"
 
 jobs:
   Experiment:
@@ -32,6 +33,8 @@ jobs:
         with:
           downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Increase API calls timeout
+        run: echo "read.timeout=$READ_TIMEOUT" | tee -a network.settings
       - name: Ignore Test Failures
         run: |
           mkdir ~/git-hooks

--- a/.github/workflows/run-experiments-apache-jmeter.yml
+++ b/.github/workflows/run-experiments-apache-jmeter.yml
@@ -34,7 +34,7 @@ jobs:
           downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Increase API calls timeout
-        run: echo "read.timeout=$READ_TIMEOUT" | tee -a network.settings
+        run: echo "read.timeout=$READ_TIMEOUT" | tee -a develocity-gradle-build-validation/network.settings
       - name: Ignore Test Failures
         run: |
           mkdir ~/git-hooks

--- a/.github/workflows/run-experiments-apache-openwhisk.yml
+++ b/.github/workflows/run-experiments-apache-openwhisk.yml
@@ -10,6 +10,7 @@ env:
   DEVELOCITY_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/apache/openwhisk"
   TASKS: ":tests:testCoverageLean :tests:reportCoverage :tests:testSwaggerCodegen"
+  READ_TIMEOUT: "PT30S"
 
 jobs:
   Experiment:
@@ -32,6 +33,8 @@ jobs:
         with:
           downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Increase API calls timeout
+        run: echo "read.timeout=$READ_TIMEOUT" | tee -a develocity-gradle-build-validation/network.settings
       - name: Run experiment 1
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
         env:

--- a/.github/workflows/run-experiments-apereo-cas.yml
+++ b/.github/workflows/run-experiments-apereo-cas.yml
@@ -10,6 +10,7 @@ env:
   DEVELOCITY_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/apereo/cas"
   TASKS: "build testCAS testLogout testGroovy testTickets -x check"
+  READ_TIMEOUT: "PT30S"
 
 jobs:
   Experiment:
@@ -31,6 +32,8 @@ jobs:
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Increase API calls timeout
+        run: echo "read.timeout=$READ_TIMEOUT" | tee -a develocity-gradle-build-validation/network.settings
       - name: Run experiment 1
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
         env:

--- a/.github/workflows/run-experiments-micronaut-starter.yml
+++ b/.github/workflows/run-experiments-micronaut-starter.yml
@@ -11,6 +11,7 @@ env:
   GIT_REPO: "https://github.com/micronaut-projects/micronaut-starter"
   TASKS: "check"
   ARGS: "-DpredictiveTestSelection=false -x test-aws:test -x test-buildtool:test -x test-cli:test -x test-cloud:test -x test-core:test -x test-features:test"
+  READ_TIMEOUT: "PT30S"
 
 jobs:
   Experiment:
@@ -32,6 +33,8 @@ jobs:
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Increase API calls timeout
+        run: echo "read.timeout=$READ_TIMEOUT" | tee -a develocity-gradle-build-validation/network.settings
       - name: Run experiment 1
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
         env:

--- a/.github/workflows/run-experiments-morphia.yml
+++ b/.github/workflows/run-experiments-morphia.yml
@@ -10,6 +10,7 @@ env:
   DEVELOCITY_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/MorphiaOrg/morphia"
   GOALS: "install"
+  READ_TIMEOUT: "PT30S"
 
 jobs:
   Experiment:
@@ -30,6 +31,8 @@ jobs:
         uses: gradle/develocity-build-validation-scripts/.github/actions/maven/download@actions-stable
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Increase API calls timeout
+        run: echo "read.timeout=$READ_TIMEOUT" | tee -a develocity-maven-build-validation/network.settings
       - name: Run experiment 1
         uses: gradle/develocity-build-validation-scripts/.github/actions/maven/experiment-1@actions-stable
         env:

--- a/.github/workflows/run-experiments-spring-framework.yml
+++ b/.github/workflows/run-experiments-spring-framework.yml
@@ -10,6 +10,7 @@ env:
   DEVELOCITY_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/spring-projects/spring-framework"
   TASKS: "build"
+  READ_TIMEOUT: "PT30S"
 
 jobs:
   Experiment:
@@ -37,6 +38,8 @@ jobs:
         with:
           downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Increase API calls timeout
+        run: echo "read.timeout=$READ_TIMEOUT" | tee -a develocity-gradle-build-validation/network.settings
       - name: Run experiment 1
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
         env:

--- a/.github/workflows/run-experiments-spring-kafka.yml
+++ b/.github/workflows/run-experiments-spring-kafka.yml
@@ -10,6 +10,7 @@ env:
   DEVELOCITY_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/spring-projects/spring-kafka"
   TASKS: "build"
+  READ_TIMEOUT: "PT30S"
 
 jobs:
   Experiment:
@@ -32,6 +33,8 @@ jobs:
         with:
           downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Increase API calls timeout
+        run: echo "read.timeout=$READ_TIMEOUT" | tee -a develocity-gradle-build-validation/network.settings
       - name: Run experiment 1
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
         env:

--- a/.github/workflows/run-experiments-spring-security.yml
+++ b/.github/workflows/run-experiments-spring-security.yml
@@ -10,6 +10,7 @@ env:
   DEVELOCITY_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/spring-projects/spring-security"
   TASKS: "build"
+  READ_TIMEOUT: "PT30S"
 
 jobs:
   Experiment:
@@ -32,6 +33,8 @@ jobs:
         with:
           downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Increase API calls timeout
+        run: echo "read.timeout=$READ_TIMEOUT" | tee -a develocity-gradle-build-validation/network.settings
       - name: Run experiment 1
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
         env:


### PR DESCRIPTION
Increase API read timeout for the following workflows:

- [Spring Framework](https://github.com/gradle/develocity-oss-projects/actions/runs/13353531882)
- [Apache Calcite](https://github.com/gradle/develocity-oss-projects/actions/runs/13353505508)
- [Apache Groovy](https://github.com/gradle/develocity-oss-projects/actions/runs/13353536125)
- [Apache JMeter](https://github.com/gradle/develocity-oss-projects/actions/runs/13353543363)
- [Apache OpenWhisk](https://github.com/gradle/develocity-oss-projects/actions/runs/13353537611)
- [Spring Kafka](https://github.com/gradle/develocity-oss-projects/actions/runs/13353525523)
- [Spring Security](https://github.com/gradle/develocity-oss-projects/actions/runs/13353512760)
- [Apereo CAS](https://github.com/gradle/develocity-oss-projects/actions/runs/13353526000)
- [Micronaut Starter](https://github.com/gradle/develocity-oss-projects/actions/runs/13353512677)
- [Morphia](https://github.com/gradle/develocity-oss-projects/actions/runs/13353533030)

Tested to fix the **timeout** failures in 3 of the workflows (though they now fail for cache misses):

- [Morphia](https://github.com/gradle/develocity-oss-projects/actions/runs/13505896308)
- [Apereo CAS](https://github.com/gradle/develocity-oss-projects/actions/runs/13505920224)
- [Micronaut Starter](https://github.com/gradle/develocity-oss-projects/actions/runs/13505942645)
