### PR TITLE
Enforce Build Scan publishing in Kotlin and OpenRewrite

### DIFF
--- a/.github/workflows/run-experiments-kotlin.yml
+++ b/.github/workflows/run-experiments-kotlin.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable

--- a/.github/workflows/run-experiments-openrewrite.yml
+++ b/.github/workflows/run-experiments-openrewrite.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Download latest version of the validation scripts
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
+          downloadDevelopmentRelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable


### PR DESCRIPTION
The latest runs of [Kotlin's][K1] and [OpenRewrite's][OR1] validation workflows have been failing due to the builds not publishing a Build Scan. Enforce publishing by having the workflows download the development release of build-validation-scripts. Publishing isn't currently enforced by latest v2.7.3 for builds using the Develocity plugin, but is starting from [this commit][2].

[Kotlin's][K2] and [OpenRewrite's][OR2] workflows successfully publish build scans after this change.

[1]: https://github.com/gradle/develocity-build-validation-scripts/commit/ecb66f801ec59228c306f334bb2a15c04a484da4
[2]: https://github.com/gradle/develocity-oss-projects/actions/runs/13353528783
[OR1]: https://github.com/gradle/develocity-oss-projects/actions/runs/13481531693/job/37667355367
[OR2]: https://github.com/gradle/develocity-oss-projects/actions/runs/13546592717/job/37859622952#step:4:1138
[K1]: https://github.com/gradle/develocity-oss-projects/actions/runs/13353528783
[K2]: https://github.com/gradle/develocity-oss-projects/actions/runs/13546592249