### PR TITLE
Fix Lucene workflow JDK failure

### DIFF
--- a/.github/workflows/run-experiments-apache-lucene.yml
+++ b/.github/workflows/run-experiments-apache-lucene.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 23
           distribution: "temurin"
       - name: Download latest version of the validation scripts
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable


### PR DESCRIPTION
Lucene: Update JDK to 23 (based on [the last workflow's error message][1]). [A new run][2] no longer fails due to JDK version (though it fails for a different reason).

#138 had recently updated Lucene's JDK to 21. The project must have since moved to 23.

[1]: https://github.com/gradle/develocity-oss-projects/actions/runs/13576709883/job/37954505517
[2]: https://github.com/gradle/develocity-oss-projects/actions/runs/13588428798