### PR TITLE
Add workflow for rewrite-spring

### DIFF
--- a/.github/workflows/run-experiments-openrewrite-spring.yml
+++ b/.github/workflows/run-experiments-openrewrite-spring.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: "0 23 * * 3"
   workflow_dispatch:
-  push:
-    branches:
-      - gf/add-rewrite-spring
 
 env:
   DEVELOCITY_URL: "https://ge.solutions-team.gradle.com"

--- a/.github/workflows/run-experiments-openrewrite-spring.yml
+++ b/.github/workflows/run-experiments-openrewrite-spring.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 23 * * 3"
   workflow_dispatch:
+  push:
+    branches:
+      - gf/add-rewrite-spring
 
 env:
   DEVELOCITY_URL: "https://ge.solutions-team.gradle.com"

--- a/.github/workflows/run-experiments-openrewrite-spring.yml
+++ b/.github/workflows/run-experiments-openrewrite-spring.yml
@@ -1,0 +1,62 @@
+name: OpenRewrite Spring
+
+on:
+  schedule:
+    - cron: "0 23 * * 3"
+  workflow_dispatch:
+
+env:
+  DEVELOCITY_URL: "https://ge.solutions-team.gradle.com"
+  GIT_REPO: "https://github.com/openrewrite/rewrite-spring"
+  TASKS: "build"
+
+jobs:
+  Experiment:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - experimentId: 1
+          - experimentId: 2
+          - experimentId: 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: "temurin"
+      - name: Download latest version of the validation scripts
+        uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable
+        with:
+          downloadDevelopmentRelease: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run experiment 1
+        uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
+        env:
+          DEVELOCITY_ACCESS_KEY: "${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}"
+        with:
+          gitRepo: ${{ env.GIT_REPO }}
+          tasks: ${{ env.TASKS }}
+          develocityUrl: ${{ env.DEVELOCITY_URL }}
+        if: matrix.experimentId == 1
+      - name: Run experiment 2
+        uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-2@actions-stable
+        env:
+          DEVELOCITY_ACCESS_KEY: "${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}"
+        with:
+          gitRepo: ${{ env.GIT_REPO }}
+          tasks: ${{ env.TASKS }}
+          develocityUrl: ${{ env.DEVELOCITY_URL }}
+          failIfNotFullyCacheable: true
+        if: matrix.experimentId == 2
+      - name: Run experiment 3
+        uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-3@actions-stable
+        env:
+          DEVELOCITY_ACCESS_KEY: "${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}"
+        with:
+          gitRepo: ${{ env.GIT_REPO }}
+          tasks: ${{ env.TASKS }}
+          develocityUrl: ${{ env.DEVELOCITY_URL }}
+          failIfNotFullyCacheable: true
+        if: matrix.experimentId == 3


### PR DESCRIPTION
Add a workflow to run develocity-build-validation-scripts against the [rewrite-spring][0] build, as suggested by @timtebeek [here][1]. Along with [rewrite][2], which already has a workflow, this covers both OpenRewrite's most demanding builds.

An example first run is [here][3]. It currently fails for test failures on script 1 (incremental build) and cache misses on scripts 2 (local build caching) and 3 (local build caching at different locations).

[0]: https://github.com/openrewrite/rewrite-spring
[1]: https://github.com/openrewrite/rewrite/pull/5095#issuecomment-2686381265
[2]: https://github.com/openrewrite/rewrite
[3]: https://github.com/gradle/develocity-oss-projects/actions/runs/13592740155
