### PR TITLE
Upgrade setup-maven action

### DIFF
--- a/.github/workflows/run-experiments-quarkus.yml
+++ b/.github/workflows/run-experiments-quarkus.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.17.0
+        uses: s4u/setup-maven-action@v1.18.0
         with:
           checkout-fetch-depth: 0
           java-version: 17

--- a/.github/workflows/run-experiments-xwiki.yml
+++ b/.github/workflows/run-experiments-xwiki.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.17.0
+        uses: s4u/setup-maven-action@v1.18.0
         with:
           checkout-fetch-depth: 0
           java-version: 17


### PR DESCRIPTION
### Issue
[XWiki](https://github.com/gradle/develocity-oss-projects/actions/runs/13861650754
) and [Quarkus](https://github.com/gradle/develocity-oss-projects/actions/runs/13885975952) workflows are failing due to

```
This request has been automatically failed because it uses a deprecated version of `actions/cache: 6849a6489940f00c2f30c0fb92c6274307ccb58a`. Please update your workflow to use v3/v4 of actions/cache
```

### Fix
Upgrade `setup-maven` action to [1.18.0](https://github.com/s4u/setup-maven-action/releases/tag/v1.18.0)
