### PR TITLE
Configure dependabot to ignore develocity-build-validation-scripts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
     schedule:
       interval: "daily"
       time: "02:00"
+    ignore:
+      # develocity-build-validation-scripts do not have semantic versioning
+      - dependency-name: "*develocity-build-validation-scripts*"


### PR DESCRIPTION
### DRAFT - DO NOT REVIEW
Latest dependabot  runs were successful, maybe GitHub did an update to ignore the failures when an action does not follow a semantic versioning scheme

Let's keep this PR as a draft until next dependabot upgrade PR on an action